### PR TITLE
Load DeepSeek API key from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Project Overview
+
+This repository contains scripts and notebooks for embedding extraction and other experiments.
+
+## Environment Variables
+
+To use the DeepSeek API within `deepseek2.py`, you must set the `DEEPSEEK_API_KEY` environment variable in your deployment environment. Example:
+
+```bash
+export DEEPSEEK_API_KEY=your_api_key_here
+```
+
+Ensure this variable is configured before running any scripts that depend on DeepSeek.

--- a/deepseek2.py
+++ b/deepseek2.py
@@ -11,7 +11,9 @@ MAX_ATTEMPTS = 15
 
 # Path to the target script to fix
 FILE_PATH = r"C:\Users\Lenovo\.spyder-py3\xtts_match_embed.py"
-DEEPSEEK_API_KEY = "sk-1af9e4036f7d4bd4b6f2e0791c170489"
+DEEPSEEK_API_KEY = os.getenv("DEEPSEEK_API_KEY")
+if not DEEPSEEK_API_KEY:
+    raise RuntimeError("DEEPSEEK_API_KEY environment variable is not set")
 DEEPSEEK_API_URL = "https://api.deepseek.com/v1/chat/completions"
 
 # Enhanced logging setup


### PR DESCRIPTION
## Summary
- Read DeepSeek API key from the `DEEPSEEK_API_KEY` environment variable with explicit error if missing
- Document the `DEEPSEEK_API_KEY` requirement for deployment

## Testing
- `python -m py_compile deepseek2.py`


------
https://chatgpt.com/codex/tasks/task_e_689dbdd28474832089991bc6f7dc627d