### PR TITLE
Add CORT complexity metric with CLI integration

### DIFF
--- a/homophone-agent-audio/README.md
+++ b/homophone-agent-audio/README.md
@@ -75,7 +75,8 @@ The modules under `src/` correspond to different parts of the pipeline:
   replacements for tokens in a sentence using the BK‑tree.  It does not
   perform any part‑of‑speech filtering; integrate with a tagger if needed.
 * `scoring.py` combines phonetic, semantic and fluency scores into a single
-  objective.  Stub functions are provided for semantic and fluency scoring.
+  objective.  A simple CORT complexity metric can also be incorporated with
+  a configurable weight.
 * `co_optimization.py` sketches a simple A⇄B co‑optimization loop.  Both the
   candidate generator and the function that adjusts the literal translation
   are passed in as callables so you can control how co‑optimization works.
@@ -90,8 +91,8 @@ full system; this code provides a scaffold on which to implement it.
 
 ### Audio‑assisted scoring and embedding semantics
 
-An alternate entry point, `main_audio.py`, extends the basic CLI by adding two
-optional capabilities:
+An alternate entry point, `main_audio.py`, extends the basic CLI by adding
+several optional capabilities:
 
 1. **Embedding‑based semantics.**  If the optional
    [`sentence_transformers`](https://www.sbert.net/) package is
@@ -113,18 +114,25 @@ optional capabilities:
    functions to integrate your own services.  Without overriding,
    the bonus will always be zero.
 
+3. **CORT complexity metric.**  Passing `--use-cort` enables computation of
+   a lightweight complexity score based on token length variance.  The
+   contribution of this score to the overall objective is controlled by
+   `--cort-weight` (default `0.0`).
+
 Example usage:
 
 ```sh
 # Install optional dependency for embeddings
 pip install sentence-transformers
-# Run with audio check enabled and a higher bonus
+# Run with audio check and CORT complexity enabled
 python main_audio.py \
   --src-text "the night rate" \
   --src-lang en \
   --tgt-lang fr \
   --use-audio-check \
-  --bonus-value 0.08
+  --bonus-value 0.08 \
+  --use-cort \
+  --cort-weight 0.05
 ```
 
 All other options from `main.py` (such as `--max-rounds` and

--- a/homophone-agent-audio/src/cort.py
+++ b/homophone-agent-audio/src/cort.py
@@ -1,0 +1,37 @@
+"""Simple complexity metric (CORT).
+
+The :func:`cort_score` function provides a lightweight heuristic for
+measuring the linguistic or structural complexity of a candidate text.
+Here we use the variance of token lengths as a proxy for complexity:
+strings with more variation in word length are treated as more complex.
+The variance is mapped into ``[0, 1]`` via ``var / (var + 1)``.
+
+The metric is intentionally simple and does not require external
+libraries so that it can run in constrained environments.
+"""
+from __future__ import annotations
+
+from typing import List
+
+
+def cort_score(candidate_text: str) -> float:
+    """Return a complexity score for ``candidate_text``.
+
+    The score is based on the variance of token lengths. Higher variance
+    implies higher complexity. The raw variance is normalised to the
+    range ``[0, 1]`` using ``var / (var + 1)``.
+
+    Args:
+        candidate_text: Text for which to compute the complexity score.
+
+    Returns:
+        A float between ``0`` (minimal complexity) and ``1`` (high
+        complexity).
+    """
+    tokens: List[str] = [t for t in candidate_text.split() if t]
+    if not tokens:
+        return 0.0
+    lengths = [len(t) for t in tokens]
+    mean = sum(lengths) / len(lengths)
+    variance = sum((l - mean) ** 2 for l in lengths) / len(lengths)
+    return max(0.0, min(1.0, variance / (variance + 1)))

--- a/homophone-agent-audio/src/phone_distance.py
+++ b/homophone-agent-audio/src/phone_distance.py
@@ -77,4 +77,5 @@ class ScoreBreakdown:
     semantic: float
     fluency: float
     prosody: float
+    complexity: float
     score: float

--- a/homophone-agent-audio/src/scoring.py
+++ b/homophone-agent-audio/src/scoring.py
@@ -7,6 +7,7 @@ class CandidateScores:
     semantic: float
     fluency: float
     prosody: float
+    complexity: float
     score: float
 
 def combine_scores(
@@ -14,16 +15,25 @@ def combine_scores(
     semantic: float,
     fluency: float,
     prosody: float = 0.0,
+    complexity: float = 0.0,
     w_ph: float = 0.45,
     w_sem: float = 0.30,
     w_flu: float = 0.15,
     w_pros: float = 0.10,
+    w_cmp: float = 0.0,
 ) -> CandidateScores:
-    combined = w_ph * phonetic + w_sem * semantic + w_flu * fluency + w_pros * prosody
+    combined = (
+        w_ph * phonetic
+        + w_sem * semantic
+        + w_flu * fluency
+        + w_pros * prosody
+        + w_cmp * complexity
+    )
     return CandidateScores(
         phonetic=phonetic,
         semantic=semantic,
         fluency=fluency,
         prosody=prosody,
+        complexity=complexity,
         score=combined,
     )


### PR DESCRIPTION
## Summary
- add `cort_score` metric based on token length variance
- expose optional complexity scoring in `judge` and combine with weighted `combine_scores`
- update CLI and documentation to toggle CORT with configurable weight

## Testing
- `pytest`
- `python homophone-agent-audio/main_audio.py --help`

------
https://chatgpt.com/codex/tasks/task_e_689de420e3fc8320a51b06248524efcd