### PR TITLE
Add CORT complexity scoring and integrate into pipeline

### DIFF
--- a/homophone-agent-audio/README.md
+++ b/homophone-agent-audio/README.md
@@ -131,3 +131,21 @@ All other options from `main.py` (such as `--max-rounds` and
 `--phonetic-threshold`) are still available.  This alternate script
 otherwise behaves identically, emitting a JSON summary of the literal
 and homophonic outputs along with component scores.
+
+### CORT complexity evaluation
+
+The project also includes a small **CORT** (Complexity/Recursion Token) metric
+that estimates the linguistic complexity of a candidate using token entropy
+and syllable variation.  The `judge` helper always computes the score and
+reports it in the rationale string.  To have the score influence the final
+objective, supply a positive weight on the command line:
+
+```sh
+python main_audio.py \
+  --src-text "the night rate" \
+  --cort-weight 0.1
+```
+
+Setting the weight to zero disables the contribution of the CORT metric.  You
+may tune the weight to prioritise either simple or more complex phrases
+depending on your experiment.

--- a/homophone-agent-audio/main_audio.py
+++ b/homophone-agent-audio/main_audio.py
@@ -126,6 +126,12 @@ def main() -> None:
         help="Score bonus to apply when a candidate passes the heard‑as test",
     )
     parser.add_argument(
+        "--cort-weight",
+        type=float,
+        default=0.0,
+        help="Weight for CORT complexity score in overall combination",
+    )
+    parser.add_argument(
         "--pairbank",
         default=None,
         help=(
@@ -169,7 +175,14 @@ def main() -> None:
     def score_candidate(B_text: str, B_ipa: str) -> ScoreBreakdown:
         # Compute component scores and combine using existing weighting
         comp = judge(src_text, ipa_src, A_text, B_text, B_ipa, phone_dist)
-        base = combine_scores(comp["phonetic"], comp["semantic"], comp["fluency"], 0.0)
+        base_raw = combine_scores(
+            comp["phonetic"],
+            comp["semantic"],
+            comp["fluency"],
+            0.0,
+            comp.get("cort", 0.0),
+            w_cort=args.cort_weight,
+        )
         # Optionally apply audio bonus; reconfirmation is not a hard gate because
         # the default audio helpers are stubs.  Clients can override
         # ``heard_as_bonus`` to integrate real TTS/ASR services.  We still call
@@ -195,13 +208,21 @@ def main() -> None:
             )
             if bonus > 0.0:
                 return ScoreBreakdown(
-                    base.phonetic,
-                    base.semantic,
-                    base.fluency,
-                    base.prosody,
-                    min(1.0, base.score + bonus),
+                    base_raw.phonetic,
+                    base_raw.semantic,
+                    base_raw.fluency,
+                    base_raw.prosody,
+                    base_raw.cort,
+                    min(1.0, base_raw.score + bonus),
                 )
-        return base
+        return ScoreBreakdown(
+            base_raw.phonetic,
+            base_raw.semantic,
+            base_raw.fluency,
+            base_raw.prosody,
+            base_raw.cort,
+            base_raw.score,
+        )
 
     # Candidate generation function
     def gen_cands(A: str) -> List[Tuple[str, str, Dict[str, Any]]]:
@@ -316,6 +337,7 @@ def main() -> None:
                     "semantic": round(s.semantic, 3),
                     "fluency": round(s.fluency, 3),
                     "prosody": round(s.prosody, 3),
+                    "cort": round(s.cort, 3),
                     "score": round(s.score, 3),
                 },
             }
@@ -333,6 +355,7 @@ def main() -> None:
             "semantic": round(best_scores.semantic, 3) if best_scores else None,
             "fluency": round(best_scores.fluency, 3) if best_scores else None,
             "prosody": round(best_scores.prosody, 3) if best_scores else None,
+            "cort": round(best_scores.cort, 3) if best_scores else None,
             "score": round(best_scores.score, 3) if best_scores else None,
         },
         "alternates": alt_list,

--- a/homophone-agent-audio/src/cort.py
+++ b/homophone-agent-audio/src/cort.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+"""Utilities for estimating recursive linguistic complexity.
+
+This module exposes a single function :func:`cort_score` which computes a
+light‑weight CORT (complexity/recursion/entropy) score for a piece of text.
+The implementation intentionally avoids external dependencies so that it can
+run in constrained environments.
+
+The heuristic combines two components:
+
+* Token entropy – Shannon entropy over lower‑cased word tokens.
+* Syllable variance – variance of a naive syllable count per token.
+
+Both components are normalised to roughly ``[0, 1]`` and averaged.  The score
+is not meant to be linguistically rigorous, merely a rough proxy for how
+"complex" or "recursive" a candidate sentence is.
+"""
+
+from collections import Counter
+import math
+import re
+
+__all__ = ["cort_score"]
+
+
+_vowel_re = re.compile(r"[aeiouy]+", re.I)
+_word_re = re.compile(r"\b\w+\b", re.U)
+
+
+def _syllable_count(word: str) -> int:
+    """Very small heuristic syllable counter.
+
+    This simply counts groups of consecutive vowels.  Every word has at least
+    one syllable.
+    """
+
+    groups = _vowel_re.findall(word)
+    return max(1, len(groups))
+
+
+def cort_score(text: str) -> float:
+    """Return a CORT complexity score for ``text``.
+
+    Args:
+        text: Input string.
+
+    Returns:
+        A float in ``[0, 1]`` where higher values roughly indicate greater
+        lexical/phonetic complexity.
+    """
+
+    text = text.strip().lower()
+    if not text:
+        return 0.0
+
+    tokens = _word_re.findall(text)
+    n = len(tokens)
+    if n == 0:
+        return 0.0
+
+    counts = Counter(tokens)
+    # Token entropy normalised by max possible entropy (log2(n)).
+    ent = -sum((c / n) * math.log(c / n, 2) for c in counts.values())
+    max_ent = math.log(n, 2) if n > 1 else 1.0
+    norm_ent = ent / max_ent
+
+    # Syllable variance normalised by square of max syllable count.
+    syll_counts = [_syllable_count(tok) for tok in tokens]
+    mean = sum(syll_counts) / n
+    var = sum((s - mean) ** 2 for s in syll_counts) / n
+    max_syll = max(syll_counts) or 1
+    norm_var = var / (max_syll ** 2)
+
+    return max(0.0, min(1.0, (norm_ent + norm_var) / 2))

--- a/homophone-agent-audio/src/judge.py
+++ b/homophone-agent-audio/src/judge.py
@@ -31,6 +31,7 @@ from .embedding import semantic_similarity
 from .orchestrator import fluency_score
 from .cognate import is_cognateish
 from .phone_distance import PhoneDistance
+from .cort import cort_score
 
 
 def judge(
@@ -53,9 +54,9 @@ def judge(
         phone_dist: A PhoneDistance instance for phonetic similarity.
 
     Returns:
-        A dictionary with keys ``phonetic``, ``semantic``, ``fluency`` and
-        ``rationale``. Scores are floats in [0, 1]. The rationale is a
-        concise human‑readable string summarizing the scores.
+        A dictionary with keys ``phonetic``, ``semantic``, ``fluency``,
+        ``cort`` and ``rationale``. Scores are floats in [0, 1]. The rationale
+        is a concise human‑readable string summarizing the scores.
     """
     # Semantic similarity between the literal translation and the candidate
     sem = semantic_similarity(A_text, B_text)
@@ -76,14 +77,17 @@ def judge(
     # Cap penalty at 0.3
     cog_pen = min(cog_pen, 0.3)
     flu_adj = max(0.0, flu - cog_pen)
+    # CORT complexity score
+    cort = cort_score(B_text)
     # Construct rationale string
     rationale = (
-        f"phonetic {phon:.3f}; semantic {sem:.3f}; fluency {flu_adj:.3f}"
+        f"phonetic {phon:.3f}; semantic {sem:.3f}; fluency {flu_adj:.3f}; cort {cort:.3f}"
     )
     return {
         "phonetic": phon,
         "semantic": sem,
         "fluency": flu_adj,
+        "cort": cort,
         "rationale": rationale,
     }
 

--- a/homophone-agent-audio/src/phone_distance.py
+++ b/homophone-agent-audio/src/phone_distance.py
@@ -77,4 +77,5 @@ class ScoreBreakdown:
     semantic: float
     fluency: float
     prosody: float
+    cort: float
     score: float

--- a/homophone-agent-audio/src/scoring.py
+++ b/homophone-agent-audio/src/scoring.py
@@ -7,6 +7,7 @@ class CandidateScores:
     semantic: float
     fluency: float
     prosody: float
+    cort: float
     score: float
 
 def combine_scores(
@@ -14,16 +15,25 @@ def combine_scores(
     semantic: float,
     fluency: float,
     prosody: float = 0.0,
+    cort: float = 0.0,
     w_ph: float = 0.45,
     w_sem: float = 0.30,
     w_flu: float = 0.15,
     w_pros: float = 0.10,
+    w_cort: float = 0.0,
 ) -> CandidateScores:
-    combined = w_ph * phonetic + w_sem * semantic + w_flu * fluency + w_pros * prosody
+    combined = (
+        w_ph * phonetic
+        + w_sem * semantic
+        + w_flu * fluency
+        + w_pros * prosody
+        + w_cort * cort
+    )
     return CandidateScores(
         phonetic=phonetic,
         semantic=semantic,
         fluency=fluency,
         prosody=prosody,
+        cort=cort,
         score=combined,
     )


### PR DESCRIPTION
## Summary
- implement `cort_score` to estimate token entropy and syllable variance
- compute and return CORT in `judge`; wire into main_audio scoring and results
- allow weighting via `combine_scores` and new `--cort-weight` CLI flag
- document how to enable or tune CORT in README

## Testing
- `python -m py_compile homophone-agent-audio/src/cort.py homophone-agent-audio/src/judge.py homophone-agent-audio/src/scoring.py homophone-agent-audio/src/phone_distance.py homophone-agent-audio/main_audio.py`


------
https://chatgpt.com/codex/tasks/task_e_689de3786c94832094739b69ab73f165