### PR TITLE
Add speech transcription module and CLI demo

### DIFF
--- a/src/joker_clef/__init__.py
+++ b/src/joker_clef/__init__.py
@@ -1,0 +1,5 @@
+"""Joker Clef speech recognition helpers."""
+
+from .transcriber import transcribe_clip
+
+__all__ = ["transcribe_clip"]

--- a/src/joker_clef/cli.py
+++ b/src/joker_clef/cli.py
@@ -1,0 +1,25 @@
+"""Command line interface for the Joker Clef speech recogniser."""
+
+from __future__ import annotations
+import argparse
+
+from .transcriber import transcribe_clip
+
+
+def respond_to_clip(clip_path: str) -> str:
+    """Transcribe a clip and format the Joker Clef response."""
+    transcription = transcribe_clip(clip_path)
+    return f"Joker Clef heard: {transcription}"
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Transcribe an audio clip and return a Joker Clef response",
+    )
+    parser.add_argument("clip", help="Path to the audio clip to transcribe")
+    args = parser.parse_args(argv)
+    print(respond_to_clip(args.clip))
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/src/joker_clef/transcriber.py
+++ b/src/joker_clef/transcriber.py
@@ -1,0 +1,35 @@
+"""Utilities for turning speech clips into text."""
+
+from __future__ import annotations
+from pathlib import Path
+
+
+def transcribe_clip(clip_path: str | Path) -> str:
+    """Transcribe an audio clip using a speech-recognition engine.
+
+    Parameters
+    ----------
+    clip_path:
+        Path to the audio clip to transcribe.
+
+    Returns
+    -------
+    str
+        The recognised text.
+
+    Notes
+    -----
+    This function requires the :mod:`speech_recognition` package and an
+    available backend such as PocketSphinx or DeepSpeech. The heavy lifting
+    is intentionally imported lazily so that tests can mock the function
+    without needing those optional dependencies installed.
+    """
+    # Import inside the function to keep optional dependencies lazy.
+    import speech_recognition as sr  # type: ignore
+
+    recognizer = sr.Recognizer()
+    audio_file = Path(clip_path)
+    with sr.AudioFile(str(audio_file)) as source:
+        audio_data = recognizer.record(source)
+    # PocketSphinx runs offline and avoids network access during demos.
+    return recognizer.recognize_sphinx(audio_data)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from joker_clef.cli import respond_to_clip
+
+
+def test_respond_to_clip_uses_transcriber(monkeypatch):
+    """Joker Clef round-trip should include the transcribed text."""
+    def fake_transcribe(path: str) -> str:
+        assert path == "dummy.wav"
+        return "hello world"
+
+    monkeypatch.setattr("joker_clef.cli.transcribe_clip", fake_transcribe)
+
+    response = respond_to_clip("dummy.wav")
+    assert response == "Joker Clef heard: hello world"


### PR DESCRIPTION
## Summary
- add speech transcription helper with lazy `speech_recognition` backend
- expose CLI to transcribe an audio clip and print a Joker Clef response
- test round-trip behaviour with mocked transcription output

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dbf7fbbe0832081247e61d78a7367